### PR TITLE
Add com3step strategy named 'elf' and improve UI

### DIFF
--- a/com.js
+++ b/com.js
@@ -58,20 +58,87 @@ function com2step(g, callback) {
   return selectedState;
 }
 
+/**
+ * 3ステップ先読み戦略: 勝てる手があればそれを選ぶ、なければ相手が勝てる手を避ける
+ * @param {Game} g - 現在のゲーム状態
+ * @param {Function} callback - 選択した次の状態を処理するコールバック関数
+ * @returns {Game|undefined} - コールバックが指定されていない場合は次の状態を返す
+ */
+function com3step(g, callback) {
+  // 有効な手の候補をすべて列挙（game.enumnextを使用）
+  const nextStates = g.enumnext();
+  
+  if (nextStates.length === 0) return; // 有効な手がない場合
+  
+  // 勝てる手を探す
+  let winningState = null;
+  for (const state of nextStates) {
+    // この手を指した後、相手が有効な手を持たない場合は勝ち
+    if (state.enumnext().length === 0) {
+      winningState = state;
+      break;
+    }
+  }
+  
+  // 勝てる手があればそれを選択
+  if (winningState) {
+    if (callback) {
+      callback(winningState);
+      return;
+    }
+    return winningState;
+  }
+  
+  // 勝てる手がない場合、相手が勝てる手を持つ状態を避ける
+  const safeStates = [];
+  for (const state of nextStates) {
+    // 相手の手を調べる
+    const opponentStates = state.enumnext();
+    
+    // 相手が勝てる手を持つかチェック
+    let opponentCanWin = false;
+    for (const opponentState of opponentStates) {
+      // 相手がこの手を指した後、自分が有効な手を持たない場合は相手の勝ち
+      if (opponentState.enumnext().length === 0) {
+        opponentCanWin = true;
+        break;
+      }
+    }
+    
+    // 相手が勝てる手を持たない場合、この手は安全
+    if (!opponentCanWin) {
+      safeStates.push(state);
+    }
+  }
+  
+  // 安全な手があればその中からランダムに選択、なければすべての手の中からランダムに選択
+  const selectedState = safeStates.length > 0 
+    ? safeStates[Math.floor(Math.random() * safeStates.length)]
+    : nextStates[Math.floor(Math.random() * nextStates.length)];
+  
+  // 選択した手を実行するためのコールバックを呼び出す
+  if (callback) {
+    callback(selectedState);
+    return;
+  }
+  
+  return selectedState;
+}
+
 // COMの戦略関数の配列
-const comStrategies = [comRandom, com2step];
+const comStrategies = [comRandom, com2step, com3step];
 
 // COMの戦略名（日本語と英語）
 const comStrategyNames = {
-  ja: ["スライム", "ゴブリン", "２人対戦"],
-  en: ["Slime", "Goblin", "Human Player"]
+  ja: ["スライム", "ゴブリン", "エルフ", "２人対戦"],
+  en: ["Slime", "Goblin", "Elf", "Human Player"]
 };
 
 // デフォルトの戦略インデックス（1: ゴブリン）
 let defaultStrategyIndex = 1;
 
-// 戦略インデックスがHuman Player（2）の場合はvsComModeをfalseにする
+// 戦略インデックスがHuman Player（3）の場合はvsComModeをfalseにする
 function updateVsComMode(strategyIndex) {
-  vsComMode = (strategyIndex !== 2);
+  vsComMode = (strategyIndex !== 3);
   return vsComMode;
 }

--- a/main.js
+++ b/main.js
@@ -79,6 +79,9 @@ window.addEventListener('DOMContentLoaded', function() {
   
   // COMの戦略選択ドロップダウンを言語に応じて初期化
   initComStrategySelect();
+  
+  // プレイヤーのキャプションを更新
+  updatePlayerCaptions();
 });
 
 // COMの戦略選択ドロップダウンを言語に応じて初期化する関数
@@ -108,12 +111,31 @@ player2StartCheckbox.addEventListener('change', function() {
   startFromPlayer2 = this.checked;
 });
 
+// プレイヤーのキャプションを更新する関数
+function updatePlayerCaptions() {
+  // プレイヤー1のキャプションを言語に応じて更新
+  player1Caption.textContent = lang === 'ja' ? 'プレイヤー1' : 'Player 1';
+  
+  // プレイヤー2のキャプションを更新
+  if (vsComMode) {
+    // COMモードの場合、モンスター名を表示
+    const monsterName = comStrategyNames[lang === 'ja' ? 'ja' : 'en'][comStrategyIndex];
+    player2Caption.textContent = monsterName;
+  } else {
+    // 2人対戦モードの場合、「Player 2」を表示
+    player2Caption.textContent = lang === 'ja' ? 'プレイヤー2' : 'Player 2';
+  }
+}
+
 // COMの戦略選択時の処理
 comStrategySelect.addEventListener('change', function() {
   comStrategyIndex = parseInt(this.value);
   // 戦略に応じてvsComModeを更新
   const prevVsComMode = vsComMode;
   updateVsComMode(comStrategyIndex);
+  
+  // プレイヤーのキャプションを更新
+  updatePlayerCaptions();
   
   // 2人対戦からCOMモードに変更され、かつ現在のターンがPlayer2の場合は、すぐにCOMの手を選択
   if (!prevVsComMode && vsComMode && game && game.turn === 2 && currentState === STATES.PUT_TURRET) {
@@ -160,7 +182,13 @@ function handleComTurn() {
         game = nextState;
         if (!game.check()) {
           const winner = game.turn === 1 ? 2 : 1;
-          setState(STATES.START_GAME, `プレイヤー${winner}の勝利です！`, `Player ${winner} won!`);
+          if (winner === 2 && vsComMode) {
+            // COMが勝利した場合、モンスター名を表示
+            const monsterName = comStrategyNames[lang === 'ja' ? 'ja' : 'en'][comStrategyIndex];
+            setState(STATES.START_GAME, `${monsterName}の勝利です！`, `${monsterName} won!`);
+          } else {
+            setState(STATES.START_GAME, `プレイヤー${winner}の勝利です！`, `Player ${winner} won!`);
+          }
         } else {
           setState(STATES.PUT_TURRET, `プレイヤー${game.turn}のタレットを配置するセルをクリックしてください`, `Click a cell to put a turret for Player ${game.turn}`);
         }
@@ -220,15 +248,15 @@ function drawBoard(candidatePos = null) {
           ctx.fill();
         } else if (cell === ikind_horizbeam) {
           const t = cellSize/6, o = (cellSize-t)/2;
-          ctx.fillStyle = 'yellow';
+          ctx.fillStyle = 'orange';
           ctx.fillRect(c*cellSize + 2, r*cellSize+o, cellSize - 4, t);
         } else if (cell === ikind_vertbeam) {
           const t = cellSize/6, o = (cellSize-t)/2;
-          ctx.fillStyle = 'yellow';
+          ctx.fillStyle = 'orange';
           ctx.fillRect(c*cellSize+o, r*cellSize + 2, t, cellSize - 4);
         } else if (cell === ikind_crossbeam) {
           const t = cellSize/6, o = (cellSize-t)/2;
-          ctx.fillStyle = 'yellow';
+          ctx.fillStyle = 'orange';
           ctx.fillRect(c*cellSize + 2, r*cellSize+o, cellSize - 4, t);
           ctx.fillRect(c*cellSize+o, r*cellSize + 2, t, cellSize - 4);
         }
@@ -371,7 +399,13 @@ boardCanvas.addEventListener('click', e => {
     game = res.next;
     if (!game.check()) {
       const winner = game.turn === 1 ? 2 : 1;
-      setState(STATES.START_GAME, `プレイヤー${winner}の勝利です！`, `Player ${winner} won!`);
+      if (winner === 2 && vsComMode) {
+        // COMが勝利した場合、モンスター名を表示
+        const monsterName = comStrategyNames[lang === 'ja' ? 'ja' : 'en'][comStrategyIndex];
+        setState(STATES.START_GAME, `${monsterName}の勝利です！`, `${monsterName} won!`);
+      } else {
+        setState(STATES.START_GAME, `プレイヤー${winner}の勝利です！`, `Player ${winner} won!`);
+      }
     } else {
       setState(STATES.PUT_TURRET, `プレイヤー${game.turn}のタレットを配置するセルをクリックしてください`, `Click a cell to put a turret for Player ${game.turn}`);
       // COMのターンなら自動的に手を選択


### PR DESCRIPTION
このPRでは以下の機能を追加・改善しています：

1. 新しいAI戦略「com3step」を追加
   - 「com2step」を拡張し、勝てる手がない場合に相手が勝ててしまう手を避ける
   - 戦略名は「エルフ」として実装

2. UI改善
   - COMが勝利した場合、「プレイヤー2の勝利です！」ではなく「[モンスター名]の勝利です！」と表示
   - ビームの色を黄色からオレンジ色に変更
   - プレイヤーのキャプションを言語に応じて表示（日本語/英語）